### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.TheRun.props
+++ b/props/LiveSplit.TheRun.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.TheRun.props
+++ b/props/LiveSplit.TheRun.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.TheRun/LiveSplit.TheRun.csproj
+++ b/src/LiveSplit.TheRun/LiveSplit.TheRun.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -136,7 +136,10 @@ public class CollectorComponent : LogicComponent
 
     private double? ConvertTime(Time time)
     {
-        if (time[State.CurrentTimingMethod] == null) return null;
+        if (time[State.CurrentTimingMethod] == null)
+        {
+            return null;
+        }
 
         TimeSpan timeSpan = (TimeSpan)time[State.CurrentTimingMethod];
 
@@ -164,7 +167,10 @@ public class CollectorComponent : LogicComponent
     public async void HandleSplit(object sender, object e)
     {
         SetGameAndCategory();
-        if (!AreSplitsValid() || !Settings.IsLiveTrackingEnabled) return;
+        if (!AreSplitsValid() || !Settings.IsLiveTrackingEnabled)
+        {
+            return;
+        }
 
         try
         {
@@ -183,12 +189,17 @@ public class CollectorComponent : LogicComponent
     public async void HandleReset(object sender, TimerPhase value)
     {
         SetGameAndCategory();
-        if (!AreSplitsValid()) return;
+        if (!AreSplitsValid())
+        {
+            return;
+        }
 
         try
         {
             if (Settings.IsLiveTrackingEnabled)
+            {
                 await UpdateSplitsState();
+            }
 
             await UploadSplits();
         }
@@ -202,7 +213,10 @@ public class CollectorComponent : LogicComponent
 
     public async Task UploadSplits()
     {
-        if (!Settings.IsStatsUploadingEnabled) return;
+        if (!Settings.IsStatsUploadingEnabled)
+        {
+            return;
+        }
 
         string FileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
         string FileUploadUrl = FileUploadBaseUrl + "?filename=" + FileName + "&uploadKey=" + Settings.UploadKey;
@@ -212,7 +226,10 @@ public class CollectorComponent : LogicComponent
 
         // Something went wrong, but the backend will handle the error, LiveSplit should just keep going.
         // Probably the upload key was not filled in.
-        if (!result.IsSuccessStatusCode) return;
+        if (!result.IsSuccessStatusCode)
+        {
+            return;
+        }
 
         JavaScriptSerializer ser = new JavaScriptSerializer();
         var JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -1,9 +1,5 @@
-﻿using LiveSplit.Model;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -13,268 +9,269 @@ using System.Web.Script.Serialization;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+
+namespace LiveSplit.UI.Components;
+
+public class CollectorComponent : LogicComponent
 {
-	public class CollectorComponent : LogicComponent
-	{
-		public override string ComponentName => "therun.gg";
+    public override string ComponentName => "therun.gg";
 
-		private LiveSplitState State { get; set; }
-		private CollectorSettings Settings { get; set; }
+    private LiveSplitState State { get; set; }
+    private CollectorSettings Settings { get; set; }
 
-		private readonly HttpClient httpClient;
+    private readonly HttpClient httpClient;
 
-		private string SplitWebhookUrl => "https://dspc6ekj2gjkfp44cjaffhjeue0fbswr.lambda-url.eu-west-1.on.aws/";
-		private string FileUploadBaseUrl => "https://2uxp372ks6nwrjnk6t7lqov4zu0solno.lambda-url.eu-west-1.on.aws/";
+    private string SplitWebhookUrl => "https://dspc6ekj2gjkfp44cjaffhjeue0fbswr.lambda-url.eu-west-1.on.aws/";
+    private string FileUploadBaseUrl => "https://2uxp372ks6nwrjnk6t7lqov4zu0solno.lambda-url.eu-west-1.on.aws/";
 
-		private string GameName = "";
-		private string CategoryName = "";
+    private string GameName = "";
+    private string CategoryName = "";
 
-		private bool TimerPaused = false;
-		private bool WasJustResumed = false;
-		private TimeSpan CurrentPausedTime = TimeSpan.Zero;
-		private TimeSpan TimePausedBeforeResume = TimeSpan.Zero;
+    private bool TimerPaused = false;
+    private bool WasJustResumed = false;
+    private TimeSpan CurrentPausedTime = TimeSpan.Zero;
+    private TimeSpan TimePausedBeforeResume = TimeSpan.Zero;
 
-		public CollectorComponent(LiveSplitState state)
-		{
-			State = state;
-			Settings = new CollectorSettings();
+    public CollectorComponent(LiveSplitState state)
+    {
+        State = state;
+        Settings = new CollectorSettings();
 
-			httpClient = new HttpClient();
-			httpClient.DefaultRequestHeaders.Add("Accept", "*/*");
-			httpClient.DefaultRequestHeaders.Add("Sec-Fetch-Site", "cross-site");
-			httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Disposition", "attachment");
+        httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("Accept", "*/*");
+        httpClient.DefaultRequestHeaders.Add("Sec-Fetch-Site", "cross-site");
+        httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Disposition", "attachment");
 
-			SetGameAndCategory();
+        SetGameAndCategory();
 
-			State.OnStart += HandleSplit;
-			State.OnSplit += HandleSplit;
-			State.OnSkipSplit += HandleSplit;
-			State.OnUndoSplit += HandleSplit;
-			State.OnUndoAllPauses += HandleSplit;
+        State.OnStart += HandleSplit;
+        State.OnSplit += HandleSplit;
+        State.OnSkipSplit += HandleSplit;
+        State.OnUndoSplit += HandleSplit;
+        State.OnUndoAllPauses += HandleSplit;
 
-			State.OnPause += HandlePause;
-			State.OnResume += HandleResume;
-			State.OnReset += HandleReset;
-		}
+        State.OnPause += HandlePause;
+        State.OnResume += HandleResume;
+        State.OnReset += HandleReset;
+    }
 
-		public async Task UpdateSplitsState()
-		{
-			object returnData = buildLiveRunData();
+    public async Task UpdateSplitsState()
+    {
+        object returnData = buildLiveRunData();
 
-			JavaScriptSerializer serializer = new JavaScriptSerializer();
-			var content = new StringContent(serializer.Serialize(returnData));
+        JavaScriptSerializer serializer = new JavaScriptSerializer();
+        var content = new StringContent(serializer.Serialize(returnData));
 
-			await httpClient.PostAsync(SplitWebhookUrl, content);
-		}
+        await httpClient.PostAsync(SplitWebhookUrl, content);
+    }
 
-		private void SetGameAndCategory()
-		{
-			GameName = State.Run.GameName;
-			CategoryName = State.Run.CategoryName;
-		}
+    private void SetGameAndCategory()
+    {
+        GameName = State.Run.GameName;
+        CategoryName = State.Run.CategoryName;
+    }
 
-		private object buildLiveRunData()
-		{
-			var run = State.Run;
-			TimeSpan? CurrentTime = State.CurrentTime[State.CurrentTimingMethod];
-			List<object> runData = new List<object>();
+    private object buildLiveRunData()
+    {
+        var run = State.Run;
+        TimeSpan? CurrentTime = State.CurrentTime[State.CurrentTimingMethod];
+        List<object> runData = new List<object>();
 
-			var MetaData = new
-			{
-				game = GameName,
-				category = CategoryName,
-				platform = run.Metadata.PlatformName,
-				region = run.Metadata.RegionName,
-				emulator = run.Metadata.UsesEmulator,
-				variables = run.Metadata.VariableValueNames
-			};
+        var MetaData = new
+        {
+            game = GameName,
+            category = CategoryName,
+            platform = run.Metadata.PlatformName,
+            region = run.Metadata.RegionName,
+            emulator = run.Metadata.UsesEmulator,
+            variables = run.Metadata.VariableValueNames
+        };
 
-			foreach (var segment in run)
-			{
-				List<object> comparisons = new List<object>();
+        foreach (var segment in run)
+        {
+            List<object> comparisons = new List<object>();
 
-				foreach (string key in segment.Comparisons.Keys)
-				{
-					comparisons.Add(new
-					{
-						name = key,
-						time = ConvertTime(segment.Comparisons[key])
-					});
-				}
+            foreach (string key in segment.Comparisons.Keys)
+            {
+                comparisons.Add(new
+                {
+                    name = key,
+                    time = ConvertTime(segment.Comparisons[key])
+                });
+            }
 
-				runData.Add(new
-				{
-					name = segment.Name,
-					splitTime = ConvertTime(segment.SplitTime),
-					pbSplitTime = ConvertTime(segment.PersonalBestSplitTime),
-					bestPossible = ConvertTime(segment.BestSegmentTime),
-					comparisons = comparisons
-				});
-			}
+            runData.Add(new
+            {
+                name = segment.Name,
+                splitTime = ConvertTime(segment.SplitTime),
+                pbSplitTime = ConvertTime(segment.PersonalBestSplitTime),
+                bestPossible = ConvertTime(segment.BestSegmentTime),
+                comparisons = comparisons
+            });
+        }
 
-			return new
-			{
-				metadata = MetaData,
-				currentTime = ConvertTime(State.CurrentTime),
-				currentSplitName = State.CurrentSplit != null ? State.CurrentSplit.Name : "",
-				currentSplitIndex = State.CurrentSplitIndex,
-				timingMethod = State.CurrentTimingMethod,
-				currentDuration = State.CurrentAttemptDuration.TotalMilliseconds,
-				startTime = State.AttemptStarted.Time.ToUniversalTime(),
-				endTime = State.AttemptEnded.Time.ToUniversalTime(),
-				uploadKey = Settings.UploadKey,
-				isPaused = TimerPaused,
-				isGameTimePaused = State.IsGameTimePaused,
-				gameTimePauseTime = State.GameTimePauseTime,
-				totalPauseTime = State.PauseTime,
-				currentPauseTime = TimePausedBeforeResume,
-				timePausedAt = State.TimePausedAt.TotalMilliseconds,
-				wasJustResumed = WasJustResumed,
-				currentComparison = State.CurrentComparison,
-				runData = runData
-			};
-		}
+        return new
+        {
+            metadata = MetaData,
+            currentTime = ConvertTime(State.CurrentTime),
+            currentSplitName = State.CurrentSplit != null ? State.CurrentSplit.Name : "",
+            currentSplitIndex = State.CurrentSplitIndex,
+            timingMethod = State.CurrentTimingMethod,
+            currentDuration = State.CurrentAttemptDuration.TotalMilliseconds,
+            startTime = State.AttemptStarted.Time.ToUniversalTime(),
+            endTime = State.AttemptEnded.Time.ToUniversalTime(),
+            uploadKey = Settings.UploadKey,
+            isPaused = TimerPaused,
+            isGameTimePaused = State.IsGameTimePaused,
+            gameTimePauseTime = State.GameTimePauseTime,
+            totalPauseTime = State.PauseTime,
+            currentPauseTime = TimePausedBeforeResume,
+            timePausedAt = State.TimePausedAt.TotalMilliseconds,
+            wasJustResumed = WasJustResumed,
+            currentComparison = State.CurrentComparison,
+            runData = runData
+        };
+    }
 
-		private double? ConvertTime(Time time)
-		{
-			if (time[State.CurrentTimingMethod] == null) return null;
+    private double? ConvertTime(Time time)
+    {
+        if (time[State.CurrentTimingMethod] == null) return null;
 
-			TimeSpan timeSpan = (TimeSpan)time[State.CurrentTimingMethod];
+        TimeSpan timeSpan = (TimeSpan)time[State.CurrentTimingMethod];
 
-			return timeSpan.TotalMilliseconds;
-		}
+        return timeSpan.TotalMilliseconds;
+    }
 
-		public async void HandlePause(object sender, object e)
-		{
-			TimerPaused = true;
-			HandleSplit(sender, e);
-		}
+    public async void HandlePause(object sender, object e)
+    {
+        TimerPaused = true;
+        HandleSplit(sender, e);
+    }
 
-		public async void HandleResume(object sender, object e)
-		{
+    public async void HandleResume(object sender, object e)
+    {
 
-			TimePausedBeforeResume = (TimeSpan)(State.PauseTime - CurrentPausedTime);
-			CurrentPausedTime = (TimeSpan)State.PauseTime;
-			TimerPaused = false;
-			WasJustResumed = true;
+        TimePausedBeforeResume = (TimeSpan)(State.PauseTime - CurrentPausedTime);
+        CurrentPausedTime = (TimeSpan)State.PauseTime;
+        TimerPaused = false;
+        WasJustResumed = true;
 
-			HandleSplit(sender, e);
-		}
+        HandleSplit(sender, e);
+    }
 
-		// TODO: Log or tell user when splits are invalid or when an error occurs. Don't just continue silently.
-		public async void HandleSplit(object sender, object e)
-		{
-			SetGameAndCategory();
-			if (!AreSplitsValid() || !Settings.IsLiveTrackingEnabled) return;
+    // TODO: Log or tell user when splits are invalid or when an error occurs. Don't just continue silently.
+    public async void HandleSplit(object sender, object e)
+    {
+        SetGameAndCategory();
+        if (!AreSplitsValid() || !Settings.IsLiveTrackingEnabled) return;
 
-			try
-			{
-				await UpdateSplitsState();
+        try
+        {
+            await UpdateSplitsState();
 
-				if (State.CurrentSplitIndex == State.Run.Count)
-				{
-					await UploadSplits();
-				}
-			}
-			catch { }
+            if (State.CurrentSplitIndex == State.Run.Count)
+            {
+                await UploadSplits();
+            }
+        }
+        catch { }
 
-			WasJustResumed = false;
-		}
+        WasJustResumed = false;
+    }
 
-		public async void HandleReset(object sender, TimerPhase value)
-		{
-			SetGameAndCategory();
-			if (!AreSplitsValid()) return;
+    public async void HandleReset(object sender, TimerPhase value)
+    {
+        SetGameAndCategory();
+        if (!AreSplitsValid()) return;
 
-			try
-			{
-				if (Settings.IsLiveTrackingEnabled)
-					await UpdateSplitsState();
+        try
+        {
+            if (Settings.IsLiveTrackingEnabled)
+                await UpdateSplitsState();
 
-				await UploadSplits();
-			}
-			catch { }
-		}
+            await UploadSplits();
+        }
+        catch { }
+    }
 
-		private bool AreSplitsValid()
-		{
-			return GameName != "" && CategoryName != "" && Settings.UploadKey.Length == 36;
-		}
+    private bool AreSplitsValid()
+    {
+        return GameName != "" && CategoryName != "" && Settings.UploadKey.Length == 36;
+    }
 
-		public async Task UploadSplits()
-		{
-			if (!Settings.IsStatsUploadingEnabled) return;
+    public async Task UploadSplits()
+    {
+        if (!Settings.IsStatsUploadingEnabled) return;
 
-			string FileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
-			string FileUploadUrl = FileUploadBaseUrl + "?filename=" + FileName + "&uploadKey=" + Settings.UploadKey;
+        string FileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
+        string FileUploadUrl = FileUploadBaseUrl + "?filename=" + FileName + "&uploadKey=" + Settings.UploadKey;
 
-			var result = await httpClient.GetAsync(FileUploadUrl);
-			var responseBody = await result.Content.ReadAsStringAsync();
+        var result = await httpClient.GetAsync(FileUploadUrl);
+        var responseBody = await result.Content.ReadAsStringAsync();
 
-			// Something went wrong, but the backend will handle the error, LiveSplit should just keep going.
-			// Probably the upload key was not filled in.
-			if (!result.IsSuccessStatusCode) return;
+        // Something went wrong, but the backend will handle the error, LiveSplit should just keep going.
+        // Probably the upload key was not filled in.
+        if (!result.IsSuccessStatusCode) return;
 
-			JavaScriptSerializer ser = new JavaScriptSerializer();
-			var JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
+        JavaScriptSerializer ser = new JavaScriptSerializer();
+        var JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
 
-			string url = HttpUtility.UrlDecode(JSONObj["url"]);
-			string correctlyEncodedUrl = EncodeUrl(url);
+        string url = HttpUtility.UrlDecode(JSONObj["url"]);
+        string correctlyEncodedUrl = EncodeUrl(url);
 
-			StringContent content = new StringContent(XmlRunAsString());
-			content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment");
+        StringContent content = new StringContent(XmlRunAsString());
+        content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment");
 
-			await httpClient.PutAsync(correctlyEncodedUrl, content);
-		}
+        await httpClient.PutAsync(correctlyEncodedUrl, content);
+    }
 
-		private string EncodeUrl(string url)
-		{
-			string[] urlParts = url.Split('&').Select(urlPart => urlPart.StartsWith("X-Amz-Credential") || urlPart.StartsWith("X-Amz-Security-Token") || urlPart.StartsWith("X-Amz-SignedHeaders") ? HttpUtility.UrlEncode(urlPart).Replace("%3d", "=") : urlPart).ToArray();
+    private string EncodeUrl(string url)
+    {
+        string[] urlParts = url.Split('&').Select(urlPart => urlPart.StartsWith("X-Amz-Credential") || urlPart.StartsWith("X-Amz-Security-Token") || urlPart.StartsWith("X-Amz-SignedHeaders") ? HttpUtility.UrlEncode(urlPart).Replace("%3d", "=") : urlPart).ToArray();
 
-			string newUrl = string.Join("&", urlParts).Replace(GameName, HttpUtility.UrlEncode(GameName)).Replace(CategoryName, HttpUtility.UrlEncode(CategoryName));
-			string username = newUrl.Replace("https://splits-bucket-main.s3.eu-west-1.amazonaws.com/", "").Split('/')[0];
+        string newUrl = string.Join("&", urlParts).Replace(GameName, HttpUtility.UrlEncode(GameName)).Replace(CategoryName, HttpUtility.UrlEncode(CategoryName));
+        string username = newUrl.Replace("https://splits-bucket-main.s3.eu-west-1.amazonaws.com/", "").Split('/')[0];
 
-			return newUrl.Replace(username, HttpUtility.UrlEncode(username));
-		}
+        return newUrl.Replace(username, HttpUtility.UrlEncode(username));
+    }
 
-		private string XmlRunAsString()
-		{
-			Model.RunSavers.XMLRunSaver runSaver = new Model.RunSavers.XMLRunSaver();
-			System.IO.MemoryStream stream = new System.IO.MemoryStream();
+    private string XmlRunAsString()
+    {
+        Model.RunSavers.XMLRunSaver runSaver = new Model.RunSavers.XMLRunSaver();
+        System.IO.MemoryStream stream = new System.IO.MemoryStream();
 
-			runSaver.Save(State.Run, stream);
+        runSaver.Save(State.Run, stream);
 
-			return Encoding.UTF8.GetString(stream.ToArray());
-		}
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
 
-		public override void Dispose()
-		{
-			State.OnStart -= HandleSplit;
-			State.OnSplit -= HandleSplit;
-			State.OnSkipSplit -= HandleSplit;
-			State.OnUndoSplit -= HandleSplit;
-			State.OnReset -= HandleReset;
+    public override void Dispose()
+    {
+        State.OnStart -= HandleSplit;
+        State.OnSplit -= HandleSplit;
+        State.OnSkipSplit -= HandleSplit;
+        State.OnUndoSplit -= HandleSplit;
+        State.OnReset -= HandleReset;
 
-			httpClient.Dispose();
-		}
+        httpClient.Dispose();
+    }
 
-		public override XmlNode GetSettings(XmlDocument document)
-		{
-			return Settings.GetSettings(document);
-		}
+    public override XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
 
-		public override Control GetSettingsControl(LayoutMode mode)
-		{
-			Settings.Mode = mode;
-			return Settings;
-		}
+    public override Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
 
-		public override void SetSettings(XmlNode settings)
-		{
-			Settings.SetSettings(settings);
-		}
+    public override void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
 
-		public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
-	}
+    public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
 }

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -76,7 +76,7 @@ public class CollectorComponent : LogicComponent
     {
         var run = State.Run;
         TimeSpan? CurrentTime = State.CurrentTime[State.CurrentTimingMethod];
-        List<object> runData = new List<object>();
+        List<object> runData = [];
 
         var MetaData = new
         {
@@ -90,7 +90,7 @@ public class CollectorComponent : LogicComponent
 
         foreach (var segment in run)
         {
-            List<object> comparisons = new List<object>();
+            List<object> comparisons = [];
 
             foreach (string key in segment.Comparisons.Keys)
             {

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -75,10 +75,10 @@ public class CollectorComponent : LogicComponent
     private object buildLiveRunData()
     {
         IRun run = State.Run;
-        TimeSpan? CurrentTime = State.CurrentTime[State.CurrentTimingMethod];
+        TimeSpan? currentTime = State.CurrentTime[State.CurrentTimingMethod];
         List<object> runData = [];
 
-        var MetaData = new
+        var metaData = new
         {
             game = GameName,
             category = CategoryName,
@@ -113,7 +113,7 @@ public class CollectorComponent : LogicComponent
 
         return new
         {
-            metadata = MetaData,
+            metadata = metaData,
             currentTime = ConvertTime(State.CurrentTime),
             currentSplitName = State.CurrentSplit != null ? State.CurrentSplit.Name : "",
             currentSplitIndex = State.CurrentSplitIndex,
@@ -222,10 +222,10 @@ public class CollectorComponent : LogicComponent
             return;
         }
 
-        string FileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
-        string FileUploadUrl = FileUploadBaseUrl + "?filename=" + FileName + "&uploadKey=" + Settings.UploadKey;
+        string fileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
+        string fileUploadUrl = FileUploadBaseUrl + "?filename=" + fileName + "&uploadKey=" + Settings.UploadKey;
 
-        HttpResponseMessage result = await httpClient.GetAsync(FileUploadUrl);
+        HttpResponseMessage result = await httpClient.GetAsync(fileUploadUrl);
         string responseBody = await result.Content.ReadAsStringAsync();
 
         // Something went wrong, but the backend will handle the error, LiveSplit should just keep going.
@@ -236,9 +236,9 @@ public class CollectorComponent : LogicComponent
         }
 
         var ser = new JavaScriptSerializer();
-        Dictionary<string, string> JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
+        Dictionary<string, string> jsonObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
 
-        string url = HttpUtility.UrlDecode(JSONObj["url"]);
+        string url = HttpUtility.UrlDecode(jsonObj["url"]);
         string correctlyEncodedUrl = EncodeUrl(url);
 
         var content = new StringContent(XmlRunAsString());

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -146,13 +146,17 @@ public class CollectorComponent : LogicComponent
         return timeSpan.TotalMilliseconds;
     }
 
+#pragma warning disable CS1998 // This async method lacks 'await' operators and will run synchronously.
     public async void HandlePause(object sender, object e)
+#pragma warning restore CS1998
     {
         TimerPaused = true;
         HandleSplit(sender, e);
     }
 
+#pragma warning disable CS1998 // This async method lacks 'await' operators and will run synchronously.
     public async void HandleResume(object sender, object e)
+#pragma warning restore CS1998
     {
 
         TimePausedBeforeResume = (TimeSpan)(State.PauseTime - CurrentPausedTime);

--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -60,7 +60,7 @@ public class CollectorComponent : LogicComponent
     {
         object returnData = buildLiveRunData();
 
-        JavaScriptSerializer serializer = new JavaScriptSerializer();
+        var serializer = new JavaScriptSerializer();
         var content = new StringContent(serializer.Serialize(returnData));
 
         await httpClient.PostAsync(SplitWebhookUrl, content);
@@ -74,7 +74,7 @@ public class CollectorComponent : LogicComponent
 
     private object buildLiveRunData()
     {
-        var run = State.Run;
+        IRun run = State.Run;
         TimeSpan? CurrentTime = State.CurrentTime[State.CurrentTimingMethod];
         List<object> runData = [];
 
@@ -88,7 +88,7 @@ public class CollectorComponent : LogicComponent
             variables = run.Metadata.VariableValueNames
         };
 
-        foreach (var segment in run)
+        foreach (ISegment segment in run)
         {
             List<object> comparisons = [];
 
@@ -141,7 +141,7 @@ public class CollectorComponent : LogicComponent
             return null;
         }
 
-        TimeSpan timeSpan = (TimeSpan)time[State.CurrentTimingMethod];
+        var timeSpan = (TimeSpan)time[State.CurrentTimingMethod];
 
         return timeSpan.TotalMilliseconds;
     }
@@ -221,8 +221,8 @@ public class CollectorComponent : LogicComponent
         string FileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
         string FileUploadUrl = FileUploadBaseUrl + "?filename=" + FileName + "&uploadKey=" + Settings.UploadKey;
 
-        var result = await httpClient.GetAsync(FileUploadUrl);
-        var responseBody = await result.Content.ReadAsStringAsync();
+        HttpResponseMessage result = await httpClient.GetAsync(FileUploadUrl);
+        string responseBody = await result.Content.ReadAsStringAsync();
 
         // Something went wrong, but the backend will handle the error, LiveSplit should just keep going.
         // Probably the upload key was not filled in.
@@ -231,13 +231,13 @@ public class CollectorComponent : LogicComponent
             return;
         }
 
-        JavaScriptSerializer ser = new JavaScriptSerializer();
-        var JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
+        var ser = new JavaScriptSerializer();
+        Dictionary<string, string> JSONObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
 
         string url = HttpUtility.UrlDecode(JSONObj["url"]);
         string correctlyEncodedUrl = EncodeUrl(url);
 
-        StringContent content = new StringContent(XmlRunAsString());
+        var content = new StringContent(XmlRunAsString());
         content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment");
 
         await httpClient.PutAsync(correctlyEncodedUrl, content);
@@ -255,8 +255,8 @@ public class CollectorComponent : LogicComponent
 
     private string XmlRunAsString()
     {
-        Model.RunSavers.XMLRunSaver runSaver = new Model.RunSavers.XMLRunSaver();
-        System.IO.MemoryStream stream = new System.IO.MemoryStream();
+        var runSaver = new Model.RunSavers.XMLRunSaver();
+        var stream = new System.IO.MemoryStream();
 
         runSaver.Save(State.Run, stream);
 

--- a/src/LiveSplit.TheRun/UI/Components/CollectorFactory.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorFactory.cs
@@ -1,26 +1,26 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(CollectorFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class CollectorFactory : IComponentFactory
 {
-    public class CollectorFactory : IComponentFactory
-    {
-        public string ComponentName => "therun.gg";
+    public string ComponentName => "therun.gg";
 
-        public string Description => "Uploads your runs to therun.gg";
+    public string Description => "Uploads your runs to therun.gg";
 
-        public ComponentCategory Category => ComponentCategory.Other;
+    public ComponentCategory Category => ComponentCategory.Other;
 
-        public IComponent Create(LiveSplitState state) => new CollectorComponent(state);
+    public IComponent Create(LiveSplitState state) => new CollectorComponent(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string UpdateURL => "https://raw.githubusercontent.com/therungg/LiveSplit.TheRun/main/";
-        public string XMLURL => UpdateURL + "update.LiveSplit.TheRun.xml";
+    public string UpdateURL => "https://raw.githubusercontent.com/therungg/LiveSplit.TheRun/main/";
+    public string XMLURL => UpdateURL + "update.LiveSplit.TheRun.xml";
 
-        public Version Version => Version.Parse("0.3.2");
-    }
+    public Version Version => Version.Parse("0.3.2");
 }

--- a/src/LiveSplit.TheRun/UI/Components/CollectorFactory.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorFactory.cs
@@ -15,7 +15,10 @@ public class CollectorFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Other;
 
-    public IComponent Create(LiveSplitState state) => new CollectorComponent(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new CollectorComponent(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -10,8 +10,8 @@ public partial class CollectorSettings : UserControl
 
     public LayoutMode Mode { get; set; }
 
-    private string UploadKeyFile = "Livesplit.TheRun/uploadkey.txt";
-    private string UploadKeyFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+    private readonly string UploadKeyFile = "Livesplit.TheRun/uploadkey.txt";
+    private readonly string UploadKeyFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
     public string UploadKey { get { return GetUploadKey(); } }
 

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -52,12 +52,18 @@ public partial class CollectorSettings : UserControl
             SaveUploadKey(key);
             return key;
         }
+
         if (!string.IsNullOrEmpty(txtPath.Text))
         {
             return txtPath.Text;
         }
+
         string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
-        if (!File.Exists(filePath)) return "";
+        if (!File.Exists(filePath))
+        {
+            return "";
+        }
+
         return File.ReadAllText(filePath).Trim();
     }
 

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -77,7 +77,7 @@ public partial class CollectorSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -40,8 +40,8 @@ public partial class CollectorSettings : UserControl
         Version version = SettingsHelper.ParseVersion(element["Version"]);
         Path = SettingsHelper.ParseString(element["Path"]);
         txtPath.Text = GetUploadKey();
-        IsStatsUploadingEnabled = element["IsStatsUploadingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsStatsUploadingEnabled"]);
-        IsLiveTrackingEnabled = element["IsLiveTrackingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsLiveTrackingEnabled"]);
+        IsStatsUploadingEnabled = element["IsStatsUploadingEnabled"] == null || SettingsHelper.ParseBool(element["IsStatsUploadingEnabled"]);
+        IsLiveTrackingEnabled = element["IsLiveTrackingEnabled"] == null || SettingsHelper.ParseBool(element["IsLiveTrackingEnabled"]);
     }
 
     private string GetUploadKey()

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -13,7 +13,7 @@ public partial class CollectorSettings : UserControl
     private readonly string UploadKeyFile = "Livesplit.TheRun/uploadkey.txt";
     private readonly string UploadKeyFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-    public string UploadKey { get { return GetUploadKey(); } }
+    public string UploadKey => GetUploadKey();
 
     public string Path { get; set; }
     public bool IsStatsUploadingEnabled { get; set; }

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -1,108 +1,107 @@
 ﻿using System;
-using System.Xml;
-using System.Windows.Forms;
 using System.IO;
+using System.Windows.Forms;
+using System.Xml;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class CollectorSettings : UserControl
 {
-	public partial class CollectorSettings : UserControl
-	{
 
-		public LayoutMode Mode { get; set; }
+    public LayoutMode Mode { get; set; }
 
-		private string UploadKeyFile = "Livesplit.TheRun/uploadkey.txt";
-		private string UploadKeyFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+    private string UploadKeyFile = "Livesplit.TheRun/uploadkey.txt";
+    private string UploadKeyFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-		public string UploadKey { get { return GetUploadKey(); } }
+    public string UploadKey { get { return GetUploadKey(); } }
 
-		public string Path { get; set; }
-		public bool IsStatsUploadingEnabled { get; set; }
-		public bool IsLiveTrackingEnabled { get; set; }
+    public string Path { get; set; }
+    public bool IsStatsUploadingEnabled { get; set; }
+    public bool IsLiveTrackingEnabled { get; set; }
 
-		public CollectorSettings()
-		{
-			InitializeComponent();
+    public CollectorSettings()
+    {
+        InitializeComponent();
 
-			chkStatsUploadEnabled.DataBindings.Add("Checked", this, "IsStatsUploadingEnabled",
-				false, DataSourceUpdateMode.OnPropertyChanged);
-			chkLiveTrackingEnabled.DataBindings.Add("Checked", this, "IsLiveTrackingEnabled",
-				false, DataSourceUpdateMode.OnPropertyChanged);
+        chkStatsUploadEnabled.DataBindings.Add("Checked", this, "IsStatsUploadingEnabled",
+            false, DataSourceUpdateMode.OnPropertyChanged);
+        chkLiveTrackingEnabled.DataBindings.Add("Checked", this, "IsLiveTrackingEnabled",
+            false, DataSourceUpdateMode.OnPropertyChanged);
 
-			Path = "";
-			IsStatsUploadingEnabled = true;
-			IsLiveTrackingEnabled = true;
-		}
+        Path = "";
+        IsStatsUploadingEnabled = true;
+        IsLiveTrackingEnabled = true;
+    }
 
-		public void SetSettings(XmlNode node)
-		{
-			var element = (XmlElement)node;
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
 
-			Version version = SettingsHelper.ParseVersion(element["Version"]);
-			Path = SettingsHelper.ParseString(element["Path"]);
-			txtPath.Text = GetUploadKey();
-			IsStatsUploadingEnabled = element["IsStatsUploadingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsStatsUploadingEnabled"]);
-			IsLiveTrackingEnabled = element["IsLiveTrackingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsLiveTrackingEnabled"]);
-		}
+        Version version = SettingsHelper.ParseVersion(element["Version"]);
+        Path = SettingsHelper.ParseString(element["Path"]);
+        txtPath.Text = GetUploadKey();
+        IsStatsUploadingEnabled = element["IsStatsUploadingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsStatsUploadingEnabled"]);
+        IsLiveTrackingEnabled = element["IsLiveTrackingEnabled"] == null ? true : SettingsHelper.ParseBool(element["IsLiveTrackingEnabled"]);
+    }
 
-		private string GetUploadKey()
-		{
-			if (!string.IsNullOrEmpty(this.Path))
-			{
-				string key = this.Path;
-				SaveUploadKey(key);
-				return key;
-			}
-			if (!string.IsNullOrEmpty(txtPath.Text))
-			{
-				return txtPath.Text;
-			}
-			string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
-			if (!File.Exists(filePath)) return "";
-			return File.ReadAllText(filePath).Trim();
-		}
+    private string GetUploadKey()
+    {
+        if (!string.IsNullOrEmpty(this.Path))
+        {
+            string key = this.Path;
+            SaveUploadKey(key);
+            return key;
+        }
+        if (!string.IsNullOrEmpty(txtPath.Text))
+        {
+            return txtPath.Text;
+        }
+        string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
+        if (!File.Exists(filePath)) return "";
+        return File.ReadAllText(filePath).Trim();
+    }
 
-		private void SaveUploadKey(string key)
-		{
-			string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
-			Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filePath));
-			File.WriteAllText(filePath, key);
-			this.Path = "";
-		}
+    private void SaveUploadKey(string key)
+    {
+        string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filePath));
+        File.WriteAllText(filePath, key);
+        this.Path = "";
+    }
 
-		public XmlNode GetSettings(XmlDocument document)
-		{
-			var parent = document.CreateElement("Settings");
-			CreateSettingsNode(document, parent);
-			return parent;
-		}
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
 
-		public int GetSettingsHashCode()
-		{
-			return CreateSettingsNode(null, null);
-		}
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
 
-		private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-		{
-			return SettingsHelper.CreateSetting(document, parent, "Version", "1.0.0") ^
-				SettingsHelper.CreateSetting(document, parent,
-					"IsStatsUploadingEnabled", IsStatsUploadingEnabled) ^
-				SettingsHelper.CreateSetting(document, parent,
-					"IsLiveTrackingEnabled", IsLiveTrackingEnabled);
-		}
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.0.0") ^
+            SettingsHelper.CreateSetting(document, parent,
+                "IsStatsUploadingEnabled", IsStatsUploadingEnabled) ^
+            SettingsHelper.CreateSetting(document, parent,
+                "IsLiveTrackingEnabled", IsLiveTrackingEnabled);
+    }
 
-		private void txtPath_TextChanged(object sender, EventArgs e)
-		{
+    private void txtPath_TextChanged(object sender, EventArgs e)
+    {
 
-		}
+    }
 
-		private void label1_Click(object sender, EventArgs e)
-		{
+    private void label1_Click(object sender, EventArgs e)
+    {
 
-		}
+    }
 
-		private void txtPath_Leave(object sender, EventArgs e)
-		{
-			SaveUploadKey(txtPath.Text);
-		}
-	}
+    private void txtPath_Leave(object sender, EventArgs e)
+    {
+        SaveUploadKey(txtPath.Text);
+    }
 }

--- a/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorSettings.cs
@@ -46,9 +46,9 @@ public partial class CollectorSettings : UserControl
 
     private string GetUploadKey()
     {
-        if (!string.IsNullOrEmpty(this.Path))
+        if (!string.IsNullOrEmpty(Path))
         {
-            string key = this.Path;
+            string key = Path;
             SaveUploadKey(key);
             return key;
         }
@@ -72,7 +72,7 @@ public partial class CollectorSettings : UserControl
         string filePath = System.IO.Path.Combine(UploadKeyFolder, UploadKeyFile);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filePath));
         File.WriteAllText(filePath, key);
-        this.Path = "";
+        Path = "";
     }
 
     public XmlNode GetSettings(XmlDocument document)


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
