### PR TITLE
Remove ConfigureAwait calls

### DIFF
--- a/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
+++ b/src/LiveSplit.TheRun/UI/Components/CollectorComponent.cs
@@ -251,9 +251,9 @@ public class CollectorComponent : LogicComponent
         string fileName = HttpUtility.UrlEncode(GameName) + "-" + HttpUtility.UrlEncode(CategoryName) + ".lss";
         string fileUploadUrl = FileUploadBaseUrl + "?filename=" + fileName + "&uploadKey=" + Settings.UploadKey;
 
-        HttpResponseMessage result = await httpClient.GetAsync(fileUploadUrl).ConfigureAwait(false);
+        HttpResponseMessage result = await httpClient.GetAsync(fileUploadUrl);
         result.EnsureSuccessStatusCode();
-        string responseBody = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+        string responseBody = await result.Content.ReadAsStringAsync();
 
         var ser = new JavaScriptSerializer();
         Dictionary<string, string> jsonObj = ser.Deserialize<Dictionary<string, string>>(responseBody);
@@ -264,7 +264,7 @@ public class CollectorComponent : LogicComponent
         var content = new StringContent(XmlRunAsString());
         content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment");
 
-        HttpResponseMessage putResult = await httpClient.PutAsync(correctlyEncodedUrl, content).ConfigureAwait(false);
+        HttpResponseMessage putResult = await httpClient.PutAsync(correctlyEncodedUrl, content);
         putResult.EnsureSuccessStatusCode();
     }
 


### PR DESCRIPTION
I believe these ConfigureAwait calls are the cause of the component crashes I was seeing here: https://github.com/LiveSplit/LiveSplit/issues/2677

Might be a better solution, but this seems to resolve the issue. Tested fix with 6 hours worth of runs with no issues.